### PR TITLE
refactor: Display location log data in multi-line format

### DIFF
--- a/src/app/admin/dashboard/page.tsx
+++ b/src/app/admin/dashboard/page.tsx
@@ -163,17 +163,15 @@ export default function DashboardPage() {
 
     if (type === 'location' && data && typeof data.latitude === 'number' && typeof data.longitude === 'number') {
       const locData = data as LocationData;
-      let summary = `Lat: ${locData.latitude.toFixed(5)}, Lon: ${locData.longitude.toFixed(5)}`;
-      if (locData.accuracy) {
-        summary += `, Acc: ${locData.accuracy.toFixed(0)}m`;
-      }
-      if (locData.city) {
-        summary += ` - ${locData.city}`;
-      }
-      if (locData.country) {
-        summary += `, ${locData.country}`;
-      }
-      return summary; // Return as simple text node
+      return (
+        <>
+          <p className="text-xs">Latitude: {locData.latitude.toFixed(5)}</p>
+          <p className="text-xs">Longitude: {locData.longitude.toFixed(5)}</p>
+          {locData.accuracy && <p className="text-xs">Accuracy: {locData.accuracy.toFixed(0)}m</p>}
+          {locData.city && <p className="text-xs">City: {locData.city}</p>}
+          {locData.country && <p className="text-xs">Country: {locData.country}</p>}
+        </>
+      );
     }
 
     if (type === 'audio' && data && typeof data.message === 'string') {


### PR DESCRIPTION
This commit updates the `formatLogData` function in `src/app/admin/dashboard/page.tsx` to change the display of 'location' type logs.

Previously, location data was rendered as a single, concise summary string. This change modifies the formatting to display each piece of location information (Latitude, Longitude, Accuracy, City, Country) on a new line, each with a descriptive label. Optional fields like accuracy, city, and country are only displayed if present.

This multi-line formatting improves the readability of detailed location data in the admin dashboard logs, as per your feedback. Formatting for other log types remains unchanged.